### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/EFCore.IndexAttribute.UnitTests/EFCore.IndexAttribute.Test.EF50/EFCore.IndexAttribute.Test.EF50.csproj
+++ b/EFCore.IndexAttribute.UnitTests/EFCore.IndexAttribute.Test.EF50/EFCore.IndexAttribute.Test.EF50.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="5.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.4" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Hi@jsakamoto, I found an issue in the EFCore.IndexAttribute.Test.EF50.csproj:

Packages Microsoft.EntityFrameworkCore.Sqlite v5.0.0, Microsoft.EntityFrameworkCore.SqlServer v5.0.0 and coverlet.collector v3.0.3 transitively introduce 170 dependencies into EntityFrameworkCore.IndexAttribute’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/EntityFrameworkCore-IndexAttribute.html)), while Microsoft.EntityFrameworkCore.Sqlite v5.0.4, Microsoft.EntityFrameworkCore.SqlServer v5.0.4 and coverlet.collector v3.1.0 can only introduce 143 dependencies ([see dependency graph after upgrades](http://202.182.124.107:8000/EntityFrameworkCore-IndexAttribute_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose